### PR TITLE
Tiny improvements to README.md

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,5 +7,4 @@
 ^[.].*$
 ^.*/[.].*$
 ^README\.Rmd$
-^man\/figures\/.*$
 ^.*\.tex$

--- a/README.Rmd
+++ b/README.Rmd
@@ -26,7 +26,7 @@ tinyspotifyr is an R wrapper for the Spotify's Web API. It is a fork of [spotify
 R version 3.2.0 (recommended)
 
 ```r
-install.packages('spotifyr')
+install.packages('tinyspotifyr')
 ```
 
 Development version

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # tinyspotifyr
 
-[![CRAN\_Status\_Badge](http://www.r-pkg.org/badges/version/tinyspotifyr?color=yellow)](https://cran.r-project.org/package=tinyspotifyr)
+[![CRAN_Status_Badge](http://www.r-pkg.org/badges/version/tinyspotifyr?color=yellow)](https://cran.r-project.org/package=tinyspotifyr)
 ![](http://cranlogs.r-pkg.org/badges/tinyspotifyr?color=yellow)
 
 ## Overview
@@ -18,7 +18,7 @@ focus of this package is to mirror the spotify api in R.
 R version 3.2.0 (recommended)
 
 ``` r
-install.packages('spotifyr')
+install.packages('tinyspotifyr')
 ```
 
 Development version


### PR DESCRIPTION
The .Rbuildignore was excluding the figure so the README at CRAN does not show it.  Also the installation instruction can now reference the package: yay CRAN!