### PR TITLE
Switch to https URLs in README.md

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -6,8 +6,8 @@ output: github_document
 
 # tinyspotifyr
 
-[![CRAN_Status_Badge](http://www.r-pkg.org/badges/version/tinyspotifyr?color=yellow)](https://cran.r-project.org/package=tinyspotifyr)
-![](http://cranlogs.r-pkg.org/badges/tinyspotifyr?color=yellow)
+[![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/tinyspotifyr?color=yellow)](https://cran.r-project.org/package=tinyspotifyr)
+![](https://cranlogs.r-pkg.org/badges/tinyspotifyr?color=yellow)
 
 ```{r, echo = FALSE}
 knitr::opts_chunk$set(

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 
 # tinyspotifyr
 
-[![CRAN_Status_Badge](http://www.r-pkg.org/badges/version/tinyspotifyr?color=yellow)](https://cran.r-project.org/package=tinyspotifyr)
-![](http://cranlogs.r-pkg.org/badges/tinyspotifyr?color=yellow)
+[![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/tinyspotifyr?color=yellow)](https://cran.r-project.org/package=tinyspotifyr)
+![](https://cranlogs.r-pkg.org/badges/tinyspotifyr?color=yellow)
 
 ## Overview
 


### PR DESCRIPTION
Minor maintenance commit and pull request here -- I noticed that in (some, old) README.md of mine old badges still using http:// were not rendering, and that was also the case in my tidyspotifyr checkout. As it seemed to be the same problem 'upstream' here (you have the two lines, yet the previewed README.md in the browser showed nothing) I made a quick PR.