### PR TITLE
Deprecate dead audio-features and recommendations endpoints

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tinyspotifyr
 Title: Tinyverse R Wrapper for the 'Spotify' Web API
-Version: 0.2.2
+Version: 0.2.2.1
 Authors@R: c(person("Troy", "Hernandez", email = "troy@cornball.ai", role = c("aut", "cre"), comment = c(ORCID = "0009-0005-4248-604X")), person("Charlie", "Thompson", email = "chuck@rcharlie.com", role = c("aut")), person("Josiah", "Parry", email = "josiah.parry@yahoo.com", role = "aut"), person("Donal", "Phipps", email = "donal.phipps@gmail.com", role = "aut"), person("Tom", "Wolff", email = "tom.wolff@duke.edu", role = "aut"))
 Description: An R wrapper for the 'Spotify' Web API
   <https://developer.spotify.com/web-api/>.

--- a/R/browse.R
+++ b/R/browse.R
@@ -224,6 +224,8 @@ get_featured_playlists <- function(locale = NULL, country = NULL, timestamp = NU
 #' @param include_seeds_in_response Optional. Boolean for whether to include seed object in response. Defaults to \code{FALSE}.
 #' @return
 #' Returns a data frame of results recommendations. See the official \href{https://developer.spotify.com/documentation/web-api/reference/browse/get-recommendations/}{Spotify Web API documentation} for more information.
+#' @details Deprecated. Spotify removed \code{GET /v1/recommendations}
+#'   (HTTP 404) in November 2024; the endpoint no longer exists.
 #' @export
 #'
 #' @examples
@@ -281,6 +283,10 @@ get_recommendations <- function(limit = 20,
                                 target_valence = NULL,
                                 authorization = get_spotify_access_token(),
                                 include_seeds_in_response = FALSE) {
+
+    .Deprecated(msg = paste("get_recommendations(): Spotify removed",
+        "GET /v1/recommendations (HTTP 404) in November 2024;",
+        "the endpoint no longer exists."))
 
     if (length(seed_artists) + length(seed_tracks) + length(seed_genres) > 5) {
         stop("Too many seed values. Up to 5 seed values may be provided in any combination of seed_artists, seed_tracks and seed_genres")

--- a/R/tracks.R
+++ b/R/tracks.R
@@ -24,6 +24,9 @@ get_track_audio_analysis <- function(id, authorization = get_spotify_access_toke
 
 #' Get audio feature information for a single track identified by its unique Spotify ID.
 #'
+#' @details Deprecated. Spotify restricted \code{GET /v1/audio-features}
+#'   (HTTP 403) in November 2024; it no longer returns data for apps without
+#'   prior access.
 #' @param ids Required. A comma-separated list of the \href{https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids}{Spotify IDs} of the tracks. Maximum: 100 IDs.
 #' @param authorization Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}
 #' @return
@@ -31,6 +34,9 @@ get_track_audio_analysis <- function(id, authorization = get_spotify_access_toke
 #' @export
 
 get_track_audio_features <- function(ids, authorization = get_spotify_access_token()) {
+    .Deprecated(msg = paste("get_track_audio_features(): Spotify restricted",
+        "GET /v1/audio-features (HTTP 403) in November 2024; it no longer",
+        "returns data for apps without prior access."))
     stopifnot(length(ids) <= 100)
     base_url <- 'https://api.spotify.com/v1/audio-features'
     params <- list(

--- a/man/get_recommendations.Rd
+++ b/man/get_recommendations.Rd
@@ -133,6 +133,10 @@ Returns a data frame of results recommendations. See the official \href{https://
 \description{
 Create a playlist-style listening experience based on seed artists, tracks and genres.
 }
+\details{
+Deprecated. Spotify removed \code{GET /v1/recommendations}
+  (HTTP 404) in November 2024; the endpoint no longer exists.
+}
 \examples{
 \dontrun{
 ## Get new Swedish music

--- a/man/get_track_audio_features.Rd
+++ b/man/get_track_audio_features.Rd
@@ -16,3 +16,8 @@ Returns a data frame of results containing track audio features data. See \url{h
 \description{
 Get audio feature information for a single track identified by its unique Spotify ID.
 }
+\details{
+Deprecated. Spotify restricted \code{GET /v1/audio-features}
+  (HTTP 403) in November 2024; it no longer returns data for apps without
+  prior access.
+}


### PR DESCRIPTION
`get_track_audio_features()` and `get_recommendations()` call Spotify endpoints that were removed/restricted in Nov 2024 — verified dead with a live grandfathered **user** token (audio-features -> 403, recommendations -> 404, while `/tracks` and `/me` return 200). 

Adds `.Deprecated()` runtime warnings and `@details` deprecation notes. Functions stay callable (they'll just warn, then fail at the API). R CMD check: 0 errors, 0 NOTEs, 1 inherent WARNING.