### PR TITLE
CRAN prep 0.2.3: dead URLs, T literal, cph, version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,8 @@
 Package: tinyspotifyr
 Title: Tinyverse R Wrapper for the 'Spotify' Web API
-Version: 0.2.2.1
-Authors@R: c(person("Troy", "Hernandez", email = "troy@cornball.ai", role = c("aut", "cre"), comment = c(ORCID = "0009-0005-4248-604X")), person("Charlie", "Thompson", email = "chuck@rcharlie.com", role = c("aut")), person("Josiah", "Parry", email = "josiah.parry@yahoo.com", role = "aut"), person("Donal", "Phipps", email = "donal.phipps@gmail.com", role = "aut"), person("Tom", "Wolff", email = "tom.wolff@duke.edu", role = "aut"))
+Version: 0.2.3
+Date: 2026-06-06
+Authors@R: c(person("Troy", "Hernandez", email = "troy@cornball.ai", role = c("aut", "cre", "cph"), comment = c(ORCID = "0009-0005-4248-604X")), person("Charlie", "Thompson", email = "chuck@rcharlie.com", role = c("aut", "cph")), person("Josiah", "Parry", email = "josiah.parry@yahoo.com", role = "aut"), person("Donal", "Phipps", email = "donal.phipps@gmail.com", role = "aut"), person("Tom", "Wolff", email = "tom.wolff@duke.edu", role = "aut"))
 Description: An R wrapper for the 'Spotify' Web API
   <https://developer.spotify.com/web-api/>.
 Depends: R (>= 3.2)

--- a/R/albums.R
+++ b/R/albums.R
@@ -5,7 +5,7 @@
 #' @param market Optional. \cr
 #' An \href{https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2}{ISO 3166-1 alpha-2 country code} or the string \code{"from_token"}. Provide this parameter if you want to apply \href{https://developer.spotify.com/documentation/general/guides/track-relinking-guide/}{Track Relinking}
 #' @return
-#' Returns a data frame of results containing album data. See the \href{https://developer.spotify.com/documentation/web-api/reference/albums/get-album/}{official documentation} for more information.
+#' Returns a data frame of results containing album data. See the \href{https://developer.spotify.com/documentation/web-api}{official documentation} for more information.
 #' @export
 
 get_album <- function(id, market = NULL, authorization = get_spotify_access_token()) {
@@ -42,7 +42,7 @@ get_album <- function(id, market = NULL, authorization = get_spotify_access_toke
 #' An \href{https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2}{ISO 3166-1 alpha-2 country code} or the string \code{"from_token"}. Provide this parameter if you want to apply \href{https://developer.spotify.com/documentation/general/guides/track-relinking-guide/}{Track Relinking}
 #' @param include_meta_info Optional. Boolean indicating whether to include full result, with meta information such as \code{"total"}, and \code{"limit"}. Defaults to \code{FALSE}.
 #' @return
-#' Returns a data frame of results containing album data. See \url{https://developer.spotify.com/documentation/web-api/reference/albums/get-album/} for more information.
+#' Returns a data frame of results containing album data. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 #' @export
 
 get_albums <- function(ids, market = NULL, authorization = get_spotify_access_token(), include_meta_info = FALSE) {
@@ -92,7 +92,7 @@ get_albums <- function(ids, market = NULL, authorization = get_spotify_access_to
 #' An \href{https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2}{ISO 3166-1 alpha-2 country code} or the string \code{"from_token"}. Provide this parameter if you want to apply \href{https://developer.spotify.com/documentation/general/guides/track-relinking-guide/}{Track Relinking}
 #' @param include_meta_info Optional. Boolean indicating whether to include full result, with meta information such as \code{"total"}, and \code{"limit"}. Defaults to \code{FALSE}.
 #' @return
-#' Returns a data frame of results containing album data. See the official API \href{https://developer.spotify.com/documentation/web-api/reference/albums/get-several-albums/}{documentation} for more information.
+#' Returns a data frame of results containing album data. See the official API \href{https://developer.spotify.com/documentation/web-api}{documentation} for more information.
 #' @export
 
 get_album_tracks <- function(id, limit = 20, offset = 0, market = NULL, authorization = get_spotify_access_token(), include_meta_info = FALSE) {

--- a/R/artists.R
+++ b/R/artists.R
@@ -3,7 +3,7 @@
 #' @param id The \href{https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids}{Spotify ID} for the artist.
 #' @param authorization Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization Guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}
 #' @return
-#' Returns a data frame of results containing album data. See \url{https://developer.spotify.com/documentation/web-api/reference/albums/get-album/} for more information.
+#' Returns a data frame of results containing album data. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 #' @export
 
 get_artist <- function(id, authorization = get_spotify_access_token()) {
@@ -28,7 +28,7 @@ get_artist <- function(id, authorization = get_spotify_access_token()) {
 #' @param authorization Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}
 #' @param include_meta_info Optional. Boolean indicating whether to include full result, with meta information such as \code{"total"}, and \code{"limit"}. Defaults to \code{FALSE}.
 #' @return
-#' Returns a data frame of results containing artist data. See \url{https://developer.spotify.com/documentation/web-api/reference/artists/get-several-artists/} for more information.
+#' Returns a data frame of results containing artist data. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 #' @export
 
 get_artists <- function(ids, authorization = get_spotify_access_token(), include_meta_info = FALSE) {
@@ -76,7 +76,7 @@ get_artists <- function(ids, authorization = get_spotify_access_token(), include
 #' @param authorization Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}
 #' @param include_meta_info Optional. Boolean indicating whether to include full result, with meta information such as \code{"total"}, and \code{"limit"}. Defaults to \code{FALSE}.
 #' @return
-#' Returns a data frame of results containing artist data. See \url{https://developer.spotify.com/documentation/web-api/reference/artists/get-several-artists/} for more information.
+#' Returns a data frame of results containing artist data. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 #' @export
 
 get_artist_albums <- function(id, include_groups = c('album', 'single', 'appears_on', 'compilation'), market = NULL, limit = 20, offset = 0, authorization = get_spotify_access_token(), include_meta_info = FALSE) {
@@ -117,7 +117,7 @@ get_artist_albums <- function(id, include_groups = c('album', 'single', 'appears
 #' @param authorization Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}
 #' @param include_meta_info Optional. Boolean indicating whether to include full result, with meta information such as \code{"total"}, and \code{"limit"}. Defaults to \code{FALSE}.
 #' @return
-#' Returns a data frame of results containing artist data. See \url{https://developer.spotify.com/documentation/web-api/reference/artists/get-several-artists/} for more information.
+#' Returns a data frame of results containing artist data. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 #' @export
 
 get_artist_top_tracks <- function(id, market = 'US', authorization = get_spotify_access_token(), include_meta_info = FALSE) {
@@ -153,7 +153,7 @@ get_artist_top_tracks <- function(id, market = 'US', authorization = get_spotify
 #' @param authorization Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}
 #' @param include_meta_info Optional. Boolean indicating whether to include full result, with meta information such as \code{"total"}, and \code{"limit"}. Defaults to \code{FALSE}.
 #' @return
-#' Returns a data frame of results containing artist data. See \url{https://developer.spotify.com/documentation/web-api/reference/artists/get-several-artists/} for more information.
+#' Returns a data frame of results containing artist data. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 #' @export
 
 get_related_artists <- function(id, authorization = get_spotify_access_token(), include_meta_info = FALSE) {

--- a/R/browse.R
+++ b/R/browse.R
@@ -4,7 +4,7 @@
 #' @param authorization Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization Guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}
 #'
 #' @return
-#' Returns a data frame of results containing album data. See \url{https://developer.spotify.com/documentation/web-api/reference/browse/get-list-categories/} for more information.
+#' Returns a data frame of results containing album data. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 #' @export
 
 get_categories <- function(authorization = get_spotify_access_token(), df = TRUE) {
@@ -35,7 +35,7 @@ get_categories <- function(authorization = get_spotify_access_token(), df = TRUE
 #' @param locale Optional. The desired language, consisting of an \href{https://en.wikipedia.org/wiki/ISO_639-1}{ISO 639-1} language code and an \href{https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2}{ISO 3166-1 alpha-2 country code}, joined by an underscore. For example: \code{es_MX}, meaning "Spanish (Mexico)". Provide this parameter if you want the category strings returned in a particular language. Note that, if \code{locale} is not supplied, or if the specified language is not available, the category strings returned will be in the Spotify default language (American English).
 #' @param authorization Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}
 #' @return
-#' Returns a list of results containing category information. See \url{https://developer.spotify.com/documentation/web-api/reference/users-profile/get-current-users-profile/} for more information.
+#' Returns a list of results containing category information. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 #' @export
 
 get_category <- function(category_id, country = NULL, locale = NULL, authorization = get_spotify_access_token()) {
@@ -67,7 +67,7 @@ get_category <- function(category_id, country = NULL, locale = NULL, authorizati
 #' @param authorization Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}
 #' @param include_meta_info Optional. Boolean indicating whether to include full result, with meta information such as \code{"total"}, and \code{"limit"}. Defaults to \code{FALSE}.
 #' @return
-#' Returns a data frame of results containing category playlists. See \url{https://developer.spotify.com/documentation/web-api/reference/users-profile/get-current-users-profile/} for more information.
+#' Returns a data frame of results containing category playlists. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 #' @export
 #'
 #' @examples
@@ -103,7 +103,7 @@ get_category_playlists <- function(category_id, market = NULL, limit = 20, offse
 #' @param authorization Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}
 #' @param include_meta_info Optional. Boolean indicating whether to include full result, with meta information such as \code{"country"}, \code{"offset"}, and \code{"limit"}. Defaults to \code{FALSE}.
 #' @return
-#' Returns a data frame of results containing new releases. See \url{https://developer.spotify.com/documentation/web-api/reference/users-profile/get-current-users-profile/} for more information.
+#' Returns a data frame of results containing new releases. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 #' @export
 #'
 #' @examples
@@ -141,7 +141,7 @@ get_new_releases <- function(country = NULL, limit = 20, offset = 0, authorizati
 #' @param authorization Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}
 #' @param include_meta_info Optional. Boolean indicating whether to include full result, with meta information such as \code{"total"}, and \code{"limit"}. Defaults to \code{FALSE}.
 #' @return
-#' Returns a data frame of results containing featured playlists. See \url{https://developer.spotify.com/documentation/web-api/reference/users-profile/get-current-users-profile/} for more information.
+#' Returns a data frame of results containing featured playlists. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 #' @export
 #'
 #' @examples
@@ -218,12 +218,12 @@ get_featured_playlists <- function(locale = NULL, country = NULL, timestamp = NU
 #' @param target_time_signature Optional. Integer indicating a target value for recommended tracks' time signature. Tracks with the attribute values nearest to the target values will be preferred. For example, you might request \code{target_energy = 0.6} and \code{target_danceability = 0.8}. All target values will be weighed equally in ranking results.
 #' @param target_valence Optional. Numeric value between 0 and 1 indicating a target value for recommended tracks' valence. Tracks with the attribute values nearest to the target values will be preferred. For example, you might request \code{target_energy = 0.6} and \code{target_danceability = 0.8}. All target values will be weighed equally in ranking results.
 #' @param seed_artists A character vector of \href{https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids}{Spotify IDs} for seed artists. Up to 5 seed values may be provided in any combination of \code{seed_artists}, \code{seed_tracks} and \code{seed_genres}.
-#' @param seed_genres A character vector of any genres in the set of \href{https://developer.spotify.com/documentation/web-api/reference/browse/get-recommendations/#available-genre-seeds}{available genre seeds}. Up to 5 seed values may be provided in any combination of \code{seed_artists}, \code{seed_tracks} and \code{seed_genres}.
+#' @param seed_genres A character vector of any genres in the set of \href{https://developer.spotify.com/documentation/web-api}{available genre seeds}. Up to 5 seed values may be provided in any combination of \code{seed_artists}, \code{seed_tracks} and \code{seed_genres}.
 #' @param seed_tracks A character vector of \href{https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids}{Spotify IDs} for a seed track. Up to 5 seed values may be provided in any combination of \code{seed_artists}, \code{seed_tracks} and \code{seed_genres}.
 #' @param authorization Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}
 #' @param include_seeds_in_response Optional. Boolean for whether to include seed object in response. Defaults to \code{FALSE}.
 #' @return
-#' Returns a data frame of results recommendations. See the official \href{https://developer.spotify.com/documentation/web-api/reference/browse/get-recommendations/}{Spotify Web API documentation} for more information.
+#' Returns a data frame of results recommendations. See the official \href{https://developer.spotify.com/documentation/web-api}{Spotify Web API documentation} for more information.
 #' @details Deprecated. Spotify removed \code{GET /v1/recommendations}
 #'   (HTTP 404) in November 2024; the endpoint no longer exists.
 #' @export

--- a/R/library.R
+++ b/R/library.R
@@ -15,7 +15,7 @@
 #' @param authorization Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization Guide} for more details. Defaults to \code{spotifyr::get_spotify_authorization_code()}. The access token must have been issued on behalf of the current user.
 #' @param include_meta_info Optional. Boolean indicating whether to include full result, with meta information such as \code{"total"}, and \code{"limit"}. Defaults to \code{FALSE}.
 #' @return
-#' Returns a data frame of results containing user profile information. See \url{https://developer.spotify.com/documentation/web-api/reference/library/get-users-saved-albums/} for more information.
+#' Returns a data frame of results containing user profile information. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 #' @export
 
 get_my_saved_albums <- function(limit = 20, offset = 0, market = NULL, authorization = get_spotify_authorization_code(), include_meta_info = FALSE) {
@@ -57,7 +57,7 @@ get_my_saved_albums <- function(limit = 20, offset = 0, market = NULL, authoriza
 #' @param authorization Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization Guide} for more details. Defaults to \code{spotifyr::get_spotify_authorization_code()}. The access token must have been issued on behalf of the current user.
 #' @param include_meta_info Optional. Boolean indicating whether to include full result, with meta information such as \code{"total"}, and \code{"limit"}. Defaults to \code{FALSE}.
 #' @return
-#' Returns a data frame of results containing user profile information. See \url{https://developer.spotify.com/documentation/web-api/reference/users-profile/get-current-users-profile/} for more information.
+#' Returns a data frame of results containing user profile information. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 #' @export
 
 get_my_saved_tracks <- function(limit = 20, offset = 0, market = NULL, authorization = get_spotify_authorization_code(), include_meta_info = FALSE) {

--- a/R/personalization.R
+++ b/R/personalization.R
@@ -14,7 +14,7 @@
 #' @param authorization Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization Guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}
 #' @param include_meta_info Optional. Boolean indicating whether to include full result, with meta information such as \code{"total"}, and \code{"limit"}. Defaults to \code{FALSE}.
 #' @return
-#' Returns a data frame of results containing track or album data. See the official API \href{https://developer.spotify.com/documentation/web-api/reference/personalization/get-users-top-artists-and-tracks/}{documentation} for more information.
+#' Returns a data frame of results containing track or album data. See the official API \href{https://developer.spotify.com/documentation/web-api}{documentation} for more information.
 #' @export
 
 get_my_top_artists_or_tracks <- function(type = NULL, limit = 20, offset = 0, time_range = 'medium_term', authorization = get_spotify_authorization_code(), include_meta_info = FALSE) {

--- a/R/player.R
+++ b/R/player.R
@@ -4,7 +4,7 @@
 #' @param authorization Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}. The access token must have been issued on behalf of the current user. \cr
 #' The access token must have the \code{user-read-currently-playing} and/or \code{user-read-playback-state} scope authorized in order to read information.
 #' @return
-#' Returns a data frame of results containing user profile information. See \url{https://developer.spotify.com/documentation/web-api/reference/users-profile/get-current-users-profile/} for more information.
+#' Returns a data frame of results containing user profile information. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 #' @export
 
 get_my_currently_playing <- function(market = NULL, authorization = get_spotify_authorization_code()) {
@@ -50,7 +50,7 @@ get_my_recently_played <- function(limit = 20, after = NULL, before = NULL, auth
 #' @param authorization Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization Guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}. The access token must have been issued on behalf of the current user. \cr
 #' The access token must have the \code{user-read-playback-state} scope authorized in order to read information.
 #' @return
-#' Returns a data frame of results containing user device information. See the official Spotify Web API \href{https://developer.spotify.com/documentation/web-api/reference/player/get-a-users-available-devices/}{documentation} for more information.
+#' Returns a data frame of results containing user device information. See the official Spotify Web API \href{https://developer.spotify.com/documentation/web-api}{documentation} for more information.
 #' @export
 
 get_my_devices <- function(authorization = get_spotify_authorization_code()) {
@@ -67,7 +67,7 @@ get_my_devices <- function(authorization = get_spotify_authorization_code()) {
 #' @param authorization Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization Guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}. The access token must have been issued on behalf of the current user. \cr
 #' The access token must have the \code{user-read-playback-state} scope authorized in order to read information.
 #' @return
-#' Returns a list containing user playback information. See the official Spotify Web API \href{https://developer.spotify.com/documentation/web-api/reference/player/get-information-about-the-users-current-playback/}{documentation} for more information.
+#' Returns a list containing user playback information. See the official Spotify Web API \href{https://developer.spotify.com/documentation/web-api}{documentation} for more information.
 #' @export
 
 get_my_current_playback <- function(market = NULL, authorization = get_spotify_authorization_code()) {

--- a/R/playlists.R
+++ b/R/playlists.R
@@ -128,7 +128,7 @@ create_playlist <- function(user_id, name, public = TRUE, collaborative = FALSE,
 #' Collaborative playlists are only retrievable for the current user and requires the \code{playlist-read-collaborative} \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/#list-of-scopes}{scope} to have been authorized by the user.
 #' @param include_meta_info Optional. Boolean indicating whether to include full result, with meta information such as \code{"total"}, and \code{"limit"}. Defaults to \code{FALSE}.
 #' @return
-#' Returns a data frame of results containing user profile information. See \url{https://developer.spotify.com/documentation/web-api/reference/users-profile/get-current-users-profile/} for more information.
+#' Returns a data frame of results containing user profile information. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 #' @export
 
 get_my_playlists <- function(limit = 20, offset = 0, authorization = get_spotify_authorization_code(), include_meta_info = FALSE) {
@@ -163,7 +163,7 @@ get_my_playlists <- function(limit = 20, offset = 0, authorization = get_spotify
 #' Collaborative playlists are only retrievable for the current user and requires the \code{playlist-read-collaborative} \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/#list-of-scopes}{scope} to have been authorized by the user.
 #' @param include_meta_info Optional. Boolean indicating whether to include full result, with meta information such as \code{"total"}, and \code{"limit"}. Defaults to \code{FALSE}.
 #' @return
-#' Returns a data frame of results containing user playlist information. See the official \href{https://developer.spotify.com/documentation/web-api/reference/playlists/get-list-users-playlists/}{Spotify Web API documentation} for more information.
+#' Returns a data frame of results containing user playlist information. See the official \href{https://developer.spotify.com/documentation/web-api}{Spotify Web API documentation} for more information.
 #' @export
 get_user_playlists <- function(user_id, limit = 20, offset = 0, authorization = get_spotify_authorization_code(), include_meta_info = FALSE) {
     base_url <- 'https://api.spotify.com/v1/users'
@@ -187,7 +187,7 @@ get_user_playlists <- function(user_id, limit = 20, offset = 0, authorization = 
 #' @param authorization Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization Guide} for more details. Defaults to \code{spotifyr::get_spotify_authorization_code()}. The access token must have been issued on behalf of the current user. \cr
 #' Current playlist image for both Public and Private playlists of any user are retrievable on provision of a valid access token.
 #' @return
-#' Returns a data frame of results containing playlist cover image information. See the official \href{https://developer.spotify.com/documentation/web-api/reference/playlists/get-playlist-cover/}{Spotify Web API Documentation} for more information.
+#' Returns a data frame of results containing playlist cover image information. See the official \href{https://developer.spotify.com/documentation/web-api}{Spotify Web API Documentation} for more information.
 #' @export
 
 get_playlist_cover_image <- function(playlist_id, authorization = get_spotify_authorization_code()) {
@@ -212,7 +212,7 @@ get_playlist_cover_image <- function(playlist_id, authorization = get_spotify_au
 #' An ISO 3166-1 alpha-2 country code or the string \code{"from_token"}. Provide this parameter if you want to apply \href{https://developer.spotify.com/documentation/general/guides/track-relinking-guide/}{Track Relinking}
 #' @param authorization Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization guide} for more details. Both Public and Private playlists belonging to any user are retrievable on provision of a valid access token. Defaults to \code{spotifyr::get_spotify_access_token()}
 #' @return
-#' Returns a data frame of results containing user profile information. See \url{https://developer.spotify.com/documentation/web-api/reference/users-profile/get-current-users-profile/} for more information.
+#' Returns a data frame of results containing user profile information. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 #' @export
 
 get_playlist <- function(playlist_id, fields = NULL, market = NULL, authorization = get_spotify_access_token()) {
@@ -251,7 +251,7 @@ get_playlist <- function(playlist_id, fields = NULL, market = NULL, authorizatio
 #' @param authorization Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization guide} for more details. Both Public and Private playlists belonging to any user are retrievable on provision of a valid access token. Defaults to \code{spotifyr::get_spotify_access_token()}
 #' @param include_meta_info Optional. Boolean indicating whether to include full result, with meta information such as \code{"total"}, and \code{"limit"}. Defaults to \code{FALSE}.
 #' @return
-#' Returns a data frame of results containing user profile information. See \url{https://developer.spotify.com/documentation/web-api/reference/users-profile/get-current-users-profile/} for more information.
+#' Returns a data frame of results containing user profile information. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 #' @export
 
 get_playlist_items <- function(playlist_id, fields = NULL, limit = 100, offset = 0, market = NULL, authorization = get_spotify_access_token(), include_meta_info = FALSE) {
@@ -295,7 +295,7 @@ get_playlist_items <- function(playlist_id, fields = NULL, limit = 100, offset =
 #' @param authorization Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization guide} for more details. Both Public and Private playlists belonging to any user are retrievable on provision of a valid access token. Defaults to \code{spotifyr::get_spotify_access_token()}
 #' @param include_meta_info Optional. Boolean indicating whether to include full result, with meta information such as \code{"total"}, and \code{"limit"}. Defaults to \code{FALSE}.
 #' @return
-#' Returns a data frame of results containing user profile information. See \url{https://developer.spotify.com/documentation/web-api/reference/users-profile/get-current-users-profile/} for more information.
+#' Returns a data frame of results containing user profile information. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 #' @export
 
 get_playlist_tracks <- function(playlist_id, fields = NULL, limit = 100, offset = 0, market = NULL, authorization = get_spotify_access_token(), include_meta_info = FALSE) {
@@ -336,7 +336,7 @@ remove_tracks_from_playlist <- function(playlist_id, uris, authorization = get_s
 
     # For DELETE request params URIs should be put in body
     uris_list <- lapply(uris, function(x) list(uri = x))
-    params <- jsonlite::toJSON(list(tracks = uris_list), auto_unbox = T)
+    params <- jsonlite::toJSON(list(tracks = uris_list), auto_unbox = TRUE)
 
     res <- httr::RETRY('DELETE', url, body = params, httr::config(token = authorization), encode = 'json')
     stop_for_status(res)
@@ -356,7 +356,7 @@ remove_tracks_from_playlist <- function(playlist_id, uris, authorization = get_s
 #     for(i in 1:length(positions)){
 #         uris_list[[i]]$positions <- list(positions[i])
 #     }
-#     params <- jsonlite::toJSON(list(tracks = uris_list), auto_unbox = T)
+#     params <- jsonlite::toJSON(list(tracks = uris_list), auto_unbox = TRUE)
 #     
 #     res <- httr::RETRY('DELETE', url, body = params, httr::config(token = authorization), encode = 'json')
 #     stop_for_status(res)

--- a/R/search.R
+++ b/R/search.R
@@ -1,6 +1,6 @@
 #' Search for an item
 #'
-#' Get Spotify Catalog information about artists, albums, tracks or playlists that match a keyword string. For more information see the official \href{https://developer.spotify.com/documentation/web-api/reference/#category-search}{documentation}.
+#' Get Spotify Catalog information about artists, albums, tracks or playlists that match a keyword string. For more information see the official \href{https://developer.spotify.com/documentation/web-api}{documentation}.
 #' @param q Required. \cr
 #' Search query keywords and optional field filters and operators.
 #' @param type A character vector of item types to search across. \cr

--- a/R/shows.R
+++ b/R/shows.R
@@ -7,7 +7,7 @@
 #' If not given, results will be returned for all markets and you are likely to get duplicate results per album, one for each market in which the album is available!
 #' @param authorization Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization Guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}
 #' @return
-#' Returns a data frame of results containing show data. See \url{https://developer.spotify.com/documentation/web-api/reference/shows/get-a-show/} for more information.
+#' Returns a data frame of results containing show data. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 #' @export
 
 get_show <- function(id, market = "US", authorization = get_spotify_access_token()){
@@ -35,7 +35,7 @@ get_show <- function(id, market = "US", authorization = get_spotify_access_token
 #' If not given, results will be returned for all markets and you are likely to get duplicate results per album, one for each market in which the album is available!
 #' @param authorization Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization Guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}
 #' @return
-#' Returns a data frame of results containing show data. See \url{https://developer.spotify.com/documentation/web-api/reference/shows/get-a-show/} for more information.
+#' Returns a data frame of results containing show data. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 #' @export
 
 get_shows <- function(ids, market = "US", authorization = get_spotify_access_token()){
@@ -64,7 +64,7 @@ get_shows <- function(ids, market = "US", authorization = get_spotify_access_tok
 #' If not given, results will be returned for all markets and you are likely to get duplicate results per album, one for each market in which the album is available!
 #' @param authorization Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization Guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}
 #' @return
-#' Returns a data frame of results containing the episode data for a show. See \url{https://developer.spotify.com/documentation/web-api/reference/shows/get-shows-episodes/} for more information.
+#' Returns a data frame of results containing the episode data for a show. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 #' @export
 
 get_shows_episodes <- function(id, market = "US", authorization = get_spotify_access_token()) {
@@ -93,7 +93,7 @@ get_shows_episodes <- function(id, market = "US", authorization = get_spotify_ac
 #' If not given, results will be returned for all markets and you are likely to get duplicate results per album, one for each market in which the album is available!
 #' @param authorization Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization Guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}
 #' @return
-#' Returns a string containing the latest episode data for a show. See \url{https://developer.spotify.com/documentation/web-api/reference/shows/get-shows-episodes/} for more information.
+#' Returns a string containing the latest episode data for a show. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 #' @export
 
 get_latest_episode <- function(id, market = "US", authorization = get_spotify_authorization_code()){

--- a/R/tracks.R
+++ b/R/tracks.R
@@ -3,7 +3,7 @@
 #' @param id The \href{https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids}{Spotify ID} for the track.
 #' @param authorization Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}
 #' @return
-#' Returns a data frame of results containing track audio analysis data. See \url{https://developer.spotify.com/documentation/web-api/reference/tracks/get-audio-analysis/} for more information.
+#' Returns a data frame of results containing track audio analysis data. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 #' @export
 
 get_track_audio_analysis <- function(id, authorization = get_spotify_access_token()) {
@@ -30,7 +30,7 @@ get_track_audio_analysis <- function(id, authorization = get_spotify_access_toke
 #' @param ids Required. A comma-separated list of the \href{https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids}{Spotify IDs} of the tracks. Maximum: 100 IDs.
 #' @param authorization Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}
 #' @return
-#' Returns a data frame of results containing track audio features data. See \url{https://developer.spotify.com/documentation/web-api/reference/tracks/get-several-audio-features/} for more information.
+#' Returns a data frame of results containing track audio features data. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 #' @export
 
 get_track_audio_features <- function(ids, authorization = get_spotify_access_token()) {
@@ -58,7 +58,7 @@ get_track_audio_features <- function(ids, authorization = get_spotify_access_tok
 #' An ISO 3166-1 alpha-2 country code or the string \code{"from_token"}. Provide this parameter if you want to apply \href{https://developer.spotify.com/documentation/general/guides/track-relinking-guide/}{Track Relinking}
 #' @param authorization Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}
 #' @return
-#' Returns a data frame of results containing track data. See \url{https://developer.spotify.com/documentation/web-api/reference/tracks/get-several-tracks/} for more information.
+#' Returns a data frame of results containing track data. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 #' @export
 
 get_track <- function(id, market = NULL, authorization = get_spotify_access_token()) {
@@ -92,7 +92,7 @@ get_track <- function(id, market = NULL, authorization = get_spotify_access_toke
 #' @param authorization Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}
 #' @param include_meta_info Optional. Boolean indicating whether to include full result, with meta information such as \code{"total"}, and \code{"limit"}. Defaults to \code{FALSE}.
 #' @return
-#' Returns a data frame of results containing track data. See \url{https://developer.spotify.com/documentation/web-api/reference/tracks/get-several-tracks/} for more information.
+#' Returns a data frame of results containing track data. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 #' @export
 
 get_tracks <- function(ids, market = NULL, authorization = get_spotify_access_token(), include_meta_info = FALSE) {

--- a/R/users_profile.R
+++ b/R/users_profile.R
@@ -3,7 +3,7 @@
 #' @param authorization Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization Guide} for more details. Defaults to \code{spotifyr::get_spotify_authorization_code()}. The access token must have been issued on behalf of the current user. \cr
 #' Reading the user’s email address requires the \code{user-read-email} scope; reading country and product subscription level requires the \code{user-read-private} scope. See \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/#list-of-scopes}{Using Scopes}.
 #' @return
-#' Returns a data frame of results containing user profile information. See \url{https://developer.spotify.com/documentation/web-api/reference/users-profile/get-current-users-profile/} for more information.
+#' Returns a data frame of results containing user profile information. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 #' @export
 
 get_my_profile <- function(authorization = get_spotify_authorization_code()) {
@@ -21,7 +21,7 @@ get_my_profile <- function(authorization = get_spotify_authorization_code()) {
 #' @param user_id Required. The user's \href{https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids}{Spotify user ID}.
 #' @param authorization Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}
 #' @return
-#' Returns a data frame of results containing user profile information. See \url{https://developer.spotify.com/documentation/web-api/reference/users-profile/get-users-profile/} for more information.
+#' Returns a data frame of results containing user profile information. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 #' @export
 
 get_user_profile <- function(user_id, authorization = get_spotify_access_token()) {

--- a/README.Rmd
+++ b/README.Rmd
@@ -19,7 +19,7 @@ knitr::opts_chunk$set(
 
 ## Overview
 
-tinyspotifyr is an R wrapper for the Spotify's Web API. It is a fork of [spotifyr](https://github.com/charlie86/spotifyr) with minimal dependencies inspired by the [tinyverse](http://www.tinyverse.org/). The focus of this package is to mirror the spotify api in R.
+tinyspotifyr is an R wrapper for the Spotify's Web API. It is a fork of [spotifyr](https://github.com/sillyplots/spotifyr) with minimal dependencies inspired by the [tinyverse](https://www.tinyverse.org/). The focus of this package is to mirror the spotify api in R.
 
 ## Installation
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -19,7 +19,7 @@ knitr::opts_chunk$set(
 
 ## Overview
 
-tinyspotifyr is an R wrapper for the Spotify's Web API. It is a fork of [spotifyr](https://cran.r-project.org/package=spotifyr) by Charlie Thompson, with minimal dependencies inspired by the [tinyverse](https://www.tinyverse.org/). The focus of this package is to mirror the spotify api in R.
+tinyspotifyr is an R wrapper for the Spotify's Web API. It is a fork of [spotifyr](https://cran.r-project.org/package=spotifyr) by Charlie Thompson, since revived at [its current location](https://github.com/sillyplots/spotifyr), with minimal dependencies inspired by the [tinyverse](https://www.tinyverse.org/). The focus of this package is to mirror the spotify api in R.
 
 ## Installation
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -19,7 +19,7 @@ knitr::opts_chunk$set(
 
 ## Overview
 
-tinyspotifyr is an R wrapper for the Spotify's Web API. It is a fork of [spotifyr](https://github.com/sillyplots/spotifyr) with minimal dependencies inspired by the [tinyverse](https://www.tinyverse.org/). The focus of this package is to mirror the spotify api in R.
+tinyspotifyr is an R wrapper for the Spotify's Web API. It is a fork of [spotifyr](https://cran.r-project.org/package=spotifyr) by Charlie Thompson, with minimal dependencies inspired by the [tinyverse](https://www.tinyverse.org/). The focus of this package is to mirror the spotify api in R.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 ## Overview
 
 tinyspotifyr is an R wrapper for the Spotify’s Web API. It is a fork of
-[spotifyr](https://github.com/charlie86/spotifyr) with minimal
-dependencies inspired by the [tinyverse](http://www.tinyverse.org/). The
+[spotifyr](https://github.com/sillyplots/spotifyr) with minimal
+dependencies inspired by the [tinyverse](https://www.tinyverse.org/). The
 focus of this package is to mirror the spotify api in R.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## Overview
 
 tinyspotifyr is an R wrapper for the Spotify’s Web API. It is a fork of
-[spotifyr](https://github.com/sillyplots/spotifyr) with minimal
+[spotifyr](https://cran.r-project.org/package=spotifyr) by Charlie Thompson, with minimal
 dependencies inspired by the [tinyverse](https://www.tinyverse.org/). The
 focus of this package is to mirror the spotify api in R.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## Overview
 
 tinyspotifyr is an R wrapper for the Spotify’s Web API. It is a fork of
-[spotifyr](https://cran.r-project.org/package=spotifyr) by Charlie Thompson, with minimal
+[spotifyr](https://cran.r-project.org/package=spotifyr) by Charlie Thompson, since revived at [its current location](https://github.com/sillyplots/spotifyr), with minimal
 dependencies inspired by the [tinyverse](https://www.tinyverse.org/). The
 focus of this package is to mirror the spotify api in R.
 

--- a/man/get_album.Rd
+++ b/man/get_album.Rd
@@ -14,7 +14,7 @@ An \href{https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2}{ISO 3166-1 alpha-2 co
 \item{authorization}{Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization Guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}}
 }
 \value{
-Returns a data frame of results containing album data. See the \href{https://developer.spotify.com/documentation/web-api/reference/albums/get-album/}{official documentation} for more information.
+Returns a data frame of results containing album data. See the \href{https://developer.spotify.com/documentation/web-api}{official documentation} for more information.
 }
 \description{
 Get Spotify catalog information for a single album.

--- a/man/get_album_tracks.Rd
+++ b/man/get_album_tracks.Rd
@@ -32,7 +32,7 @@ An \href{https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2}{ISO 3166-1 alpha-2 co
 \item{include_meta_info}{Optional. Boolean indicating whether to include full result, with meta information such as \code{"total"}, and \code{"limit"}. Defaults to \code{FALSE}.}
 }
 \value{
-Returns a data frame of results containing album data. See the official API \href{https://developer.spotify.com/documentation/web-api/reference/albums/get-several-albums/}{documentation} for more information.
+Returns a data frame of results containing album data. See the official API \href{https://developer.spotify.com/documentation/web-api}{documentation} for more information.
 }
 \description{
 Get Spotify catalog information about an album’s tracks. Optional parameters can be used to limit the number of tracks returned.

--- a/man/get_albums.Rd
+++ b/man/get_albums.Rd
@@ -17,7 +17,7 @@ An \href{https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2}{ISO 3166-1 alpha-2 co
 \item{include_meta_info}{Optional. Boolean indicating whether to include full result, with meta information such as \code{"total"}, and \code{"limit"}. Defaults to \code{FALSE}.}
 }
 \value{
-Returns a data frame of results containing album data. See \url{https://developer.spotify.com/documentation/web-api/reference/albums/get-album/} for more information.
+Returns a data frame of results containing album data. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 }
 \description{
 Get Spotify catalog information for multiple albums identified by their Spotify IDs.

--- a/man/get_artist.Rd
+++ b/man/get_artist.Rd
@@ -11,7 +11,7 @@ get_artist(id, authorization = get_spotify_access_token())
 \item{authorization}{Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization Guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}}
 }
 \value{
-Returns a data frame of results containing album data. See \url{https://developer.spotify.com/documentation/web-api/reference/albums/get-album/} for more information.
+Returns a data frame of results containing album data. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 }
 \description{
 Get Spotify catalog information for a single artist identified by their unique Spotify ID.

--- a/man/get_artist_albums.Rd
+++ b/man/get_artist_albums.Rd
@@ -40,7 +40,7 @@ Use with limit to get the next set of albums.}
 \item{include_meta_info}{Optional. Boolean indicating whether to include full result, with meta information such as \code{"total"}, and \code{"limit"}. Defaults to \code{FALSE}.}
 }
 \value{
-Returns a data frame of results containing artist data. See \url{https://developer.spotify.com/documentation/web-api/reference/artists/get-several-artists/} for more information.
+Returns a data frame of results containing artist data. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 }
 \description{
 Get Spotify catalog information for multiple artists identified by their Spotify IDs.

--- a/man/get_artist_top_tracks.Rd
+++ b/man/get_artist_top_tracks.Rd
@@ -19,7 +19,7 @@ Defaults to \code{"US"}.}
 \item{include_meta_info}{Optional. Boolean indicating whether to include full result, with meta information such as \code{"total"}, and \code{"limit"}. Defaults to \code{FALSE}.}
 }
 \value{
-Returns a data frame of results containing artist data. See \url{https://developer.spotify.com/documentation/web-api/reference/artists/get-several-artists/} for more information.
+Returns a data frame of results containing artist data. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 }
 \description{
 Get Spotify catalog information about an artist’s top tracks by country.

--- a/man/get_artists.Rd
+++ b/man/get_artists.Rd
@@ -14,7 +14,7 @@ get_artists(ids, authorization = get_spotify_access_token(),
 \item{include_meta_info}{Optional. Boolean indicating whether to include full result, with meta information such as \code{"total"}, and \code{"limit"}. Defaults to \code{FALSE}.}
 }
 \value{
-Returns a data frame of results containing artist data. See \url{https://developer.spotify.com/documentation/web-api/reference/artists/get-several-artists/} for more information.
+Returns a data frame of results containing artist data. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 }
 \description{
 Get Spotify catalog information for multiple artists identified by their Spotify IDs.

--- a/man/get_categories.Rd
+++ b/man/get_categories.Rd
@@ -11,7 +11,7 @@ get_categories(authorization = get_spotify_access_token(), df = TRUE)
 \item{df}{(default TRUE). Should the results be formatted as a data frame? If FALSE, the full response JSON will be returned as a list.}
 }
 \value{
-Returns a data frame of results containing album data. See \url{https://developer.spotify.com/documentation/web-api/reference/browse/get-list-categories/} for more information.
+Returns a data frame of results containing album data. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 }
 \description{
 Get a list of Spotify categories

--- a/man/get_category.Rd
+++ b/man/get_category.Rd
@@ -16,7 +16,7 @@ get_category(category_id, country = NULL, locale = NULL,
 \item{authorization}{Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}}
 }
 \value{
-Returns a list of results containing category information. See \url{https://developer.spotify.com/documentation/web-api/reference/users-profile/get-current-users-profile/} for more information.
+Returns a list of results containing category information. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 }
 \description{
 Get a single category used to tag items in Spotify (on, for example, the Spotify player’s “Browse” tab).

--- a/man/get_category_playlists.Rd
+++ b/man/get_category_playlists.Rd
@@ -21,7 +21,7 @@ get_category_playlists(category_id, market = NULL, limit = 20, offset = 0,
 \item{include_meta_info}{Optional. Boolean indicating whether to include full result, with meta information such as \code{"total"}, and \code{"limit"}. Defaults to \code{FALSE}.}
 }
 \value{
-Returns a data frame of results containing category playlists. See \url{https://developer.spotify.com/documentation/web-api/reference/users-profile/get-current-users-profile/} for more information.
+Returns a data frame of results containing category playlists. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 }
 \description{
 Get a list of Spotify playlists tagged with a particular category.

--- a/man/get_featured_playlists.Rd
+++ b/man/get_featured_playlists.Rd
@@ -24,7 +24,7 @@ get_featured_playlists(locale = NULL, country = NULL, timestamp = NULL,
 \item{include_meta_info}{Optional. Boolean indicating whether to include full result, with meta information such as \code{"total"}, and \code{"limit"}. Defaults to \code{FALSE}.}
 }
 \value{
-Returns a data frame of results containing featured playlists. See \url{https://developer.spotify.com/documentation/web-api/reference/users-profile/get-current-users-profile/} for more information.
+Returns a data frame of results containing featured playlists. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 }
 \description{
 Get a list of Spotify featured playlists (shown, for example, on a Spotify player’s ‘Browse’ tab).

--- a/man/get_latest_episode.Rd
+++ b/man/get_latest_episode.Rd
@@ -17,7 +17,7 @@ If not given, results will be returned for all markets and you are likely to get
 \item{authorization}{Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization Guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}}
 }
 \value{
-Returns a string containing the latest episode data for a show. See \url{https://developer.spotify.com/documentation/web-api/reference/shows/get-shows-episodes/} for more information.
+Returns a string containing the latest episode data for a show. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 }
 \description{
 Get Spotify uri information for a show's latest episodes identified by their unique Spotify ID.

--- a/man/get_my_current_playback.Rd
+++ b/man/get_my_current_playback.Rd
@@ -13,7 +13,7 @@ get_my_current_playback(market = NULL,
 The access token must have the \code{user-read-playback-state} scope authorized in order to read information.}
 }
 \value{
-Returns a list containing user playback information. See the official Spotify Web API \href{https://developer.spotify.com/documentation/web-api/reference/player/get-information-about-the-users-current-playback/}{documentation} for more information.
+Returns a list containing user playback information. See the official Spotify Web API \href{https://developer.spotify.com/documentation/web-api}{documentation} for more information.
 }
 \description{
 Get information about the user’s current playback state, including track, track progress, and active device.

--- a/man/get_my_currently_playing.Rd
+++ b/man/get_my_currently_playing.Rd
@@ -13,7 +13,7 @@ get_my_currently_playing(market = NULL,
 The access token must have the \code{user-read-currently-playing} and/or \code{user-read-playback-state} scope authorized in order to read information.}
 }
 \value{
-Returns a data frame of results containing user profile information. See \url{https://developer.spotify.com/documentation/web-api/reference/users-profile/get-current-users-profile/} for more information.
+Returns a data frame of results containing user profile information. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 }
 \description{
 Get the object currently being played on the user’s Spotify account.

--- a/man/get_my_devices.Rd
+++ b/man/get_my_devices.Rd
@@ -10,7 +10,7 @@ get_my_devices(authorization = get_spotify_authorization_code())
 The access token must have the \code{user-read-playback-state} scope authorized in order to read information.}
 }
 \value{
-Returns a data frame of results containing user device information. See the official Spotify Web API \href{https://developer.spotify.com/documentation/web-api/reference/player/get-a-users-available-devices/}{documentation} for more information.
+Returns a data frame of results containing user device information. See the official Spotify Web API \href{https://developer.spotify.com/documentation/web-api}{documentation} for more information.
 }
 \description{
 Get information about a user’s available devices.

--- a/man/get_my_playlists.Rd
+++ b/man/get_my_playlists.Rd
@@ -25,7 +25,7 @@ Collaborative playlists are only retrievable for the current user and requires t
 \item{include_meta_info}{Optional. Boolean indicating whether to include full result, with meta information such as \code{"total"}, and \code{"limit"}. Defaults to \code{FALSE}.}
 }
 \value{
-Returns a data frame of results containing user profile information. See \url{https://developer.spotify.com/documentation/web-api/reference/users-profile/get-current-users-profile/} for more information.
+Returns a data frame of results containing user profile information. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 }
 \description{
 Get a list of the playlists owned or followed by the current Spotify user.

--- a/man/get_my_profile.Rd
+++ b/man/get_my_profile.Rd
@@ -10,7 +10,7 @@ get_my_profile(authorization = get_spotify_authorization_code())
 Reading the user’s email address requires the \code{user-read-email} scope; reading country and product subscription level requires the \code{user-read-private} scope. See \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/#list-of-scopes}{Using Scopes}.}
 }
 \value{
-Returns a data frame of results containing user profile information. See \url{https://developer.spotify.com/documentation/web-api/reference/users-profile/get-current-users-profile/} for more information.
+Returns a data frame of results containing user profile information. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 }
 \description{
 Get detailed profile information about the current user (including the current user’s username).

--- a/man/get_my_saved_albums.Rd
+++ b/man/get_my_saved_albums.Rd
@@ -26,7 +26,7 @@ An \href{https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2}{ISO 3166-1 alpha-2 co
 \item{include_meta_info}{Optional. Boolean indicating whether to include full result, with meta information such as \code{"total"}, and \code{"limit"}. Defaults to \code{FALSE}.}
 }
 \value{
-Returns a data frame of results containing user profile information. See \url{https://developer.spotify.com/documentation/web-api/reference/library/get-users-saved-albums/} for more information.
+Returns a data frame of results containing user profile information. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 }
 \description{
 Get a list of the albums saved in the current Spotify user’s ‘Your Music’ library.

--- a/man/get_my_saved_tracks.Rd
+++ b/man/get_my_saved_tracks.Rd
@@ -26,7 +26,7 @@ An \href{https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2}{ISO 3166-1 alpha-2 co
 \item{include_meta_info}{Optional. Boolean indicating whether to include full result, with meta information such as \code{"total"}, and \code{"limit"}. Defaults to \code{FALSE}.}
 }
 \value{
-Returns a data frame of results containing user profile information. See \url{https://developer.spotify.com/documentation/web-api/reference/users-profile/get-current-users-profile/} for more information.
+Returns a data frame of results containing user profile information. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 }
 \description{
 Get a list of the songs saved in the current Spotify user’s ‘Your Music’ library.

--- a/man/get_my_top_artists_or_tracks.Rd
+++ b/man/get_my_top_artists_or_tracks.Rd
@@ -29,7 +29,7 @@ Use with limit to get the next set of entities.}
 \item{include_meta_info}{Optional. Boolean indicating whether to include full result, with meta information such as \code{"total"}, and \code{"limit"}. Defaults to \code{FALSE}.}
 }
 \value{
-Returns a data frame of results containing track or album data. See the official API \href{https://developer.spotify.com/documentation/web-api/reference/personalization/get-users-top-artists-and-tracks/}{documentation} for more information.
+Returns a data frame of results containing track or album data. See the official API \href{https://developer.spotify.com/documentation/web-api}{documentation} for more information.
 }
 \description{
 Get the current user’s top artists or tracks based on calculated affinity.

--- a/man/get_new_releases.Rd
+++ b/man/get_new_releases.Rd
@@ -19,7 +19,7 @@ get_new_releases(country = NULL, limit = 20, offset = 0,
 \item{include_meta_info}{Optional. Boolean indicating whether to include full result, with meta information such as \code{"country"}, \code{"offset"}, and \code{"limit"}. Defaults to \code{FALSE}.}
 }
 \value{
-Returns a data frame of results containing new releases. See \url{https://developer.spotify.com/documentation/web-api/reference/users-profile/get-current-users-profile/} for more information.
+Returns a data frame of results containing new releases. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 }
 \description{
 Get a list of new album releases featured in Spotify (shown, for example, on a Spotify player’s “Browse” tab).

--- a/man/get_playlist.Rd
+++ b/man/get_playlist.Rd
@@ -21,7 +21,7 @@ An ISO 3166-1 alpha-2 country code or the string \code{"from_token"}. Provide th
 \item{authorization}{Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization guide} for more details. Both Public and Private playlists belonging to any user are retrievable on provision of a valid access token. Defaults to \code{spotifyr::get_spotify_access_token()}}
 }
 \value{
-Returns a data frame of results containing user profile information. See \url{https://developer.spotify.com/documentation/web-api/reference/users-profile/get-current-users-profile/} for more information.
+Returns a data frame of results containing user profile information. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 }
 \description{
 Get a playlist owned by a Spotify user.

--- a/man/get_playlist_cover_image.Rd
+++ b/man/get_playlist_cover_image.Rd
@@ -13,7 +13,7 @@ get_playlist_cover_image(playlist_id,
 Current playlist image for both Public and Private playlists of any user are retrievable on provision of a valid access token.}
 }
 \value{
-Returns a data frame of results containing playlist cover image information. See the official \href{https://developer.spotify.com/documentation/web-api/reference/playlists/get-playlist-cover/}{Spotify Web API Documentation} for more information.
+Returns a data frame of results containing playlist cover image information. See the official \href{https://developer.spotify.com/documentation/web-api}{Spotify Web API Documentation} for more information.
 }
 \description{
 Get the current image associated with a specific playlist.

--- a/man/get_playlist_items.Rd
+++ b/man/get_playlist_items.Rd
@@ -33,7 +33,7 @@ An ISO 3166-1 alpha-2 country code or the string \code{"from_token"}. Provide th
 \item{include_meta_info}{Optional. Boolean indicating whether to include full result, with meta information such as \code{"total"}, and \code{"limit"}. Defaults to \code{FALSE}.}
 }
 \value{
-Returns a data frame of results containing user profile information. See \url{https://developer.spotify.com/documentation/web-api/reference/users-profile/get-current-users-profile/} for more information.
+Returns a data frame of results containing user profile information. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 }
 \description{
 Get full details of the items of a playlist owned by a Spotify user.

--- a/man/get_playlist_tracks.Rd
+++ b/man/get_playlist_tracks.Rd
@@ -33,7 +33,7 @@ An ISO 3166-1 alpha-2 country code or the string \code{"from_token"}. Provide th
 \item{include_meta_info}{Optional. Boolean indicating whether to include full result, with meta information such as \code{"total"}, and \code{"limit"}. Defaults to \code{FALSE}.}
 }
 \value{
-Returns a data frame of results containing user profile information. See \url{https://developer.spotify.com/documentation/web-api/reference/users-profile/get-current-users-profile/} for more information.
+Returns a data frame of results containing user profile information. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 }
 \description{
 Get full details of the tracks of a playlist owned by a Spotify user.

--- a/man/get_recommendations.Rd
+++ b/man/get_recommendations.Rd
@@ -35,7 +35,7 @@ get_recommendations(limit = 20, market = NULL, seed_artists = NULL,
 
 \item{seed_artists}{A character vector of \href{https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids}{Spotify IDs} for seed artists. Up to 5 seed values may be provided in any combination of \code{seed_artists}, \code{seed_tracks} and \code{seed_genres}.}
 
-\item{seed_genres}{A character vector of any genres in the set of \href{https://developer.spotify.com/documentation/web-api/reference/browse/get-recommendations/#available-genre-seeds}{available genre seeds}. Up to 5 seed values may be provided in any combination of \code{seed_artists}, \code{seed_tracks} and \code{seed_genres}.}
+\item{seed_genres}{A character vector of any genres in the set of \href{https://developer.spotify.com/documentation/web-api}{available genre seeds}. Up to 5 seed values may be provided in any combination of \code{seed_artists}, \code{seed_tracks} and \code{seed_genres}.}
 
 \item{seed_tracks}{A character vector of \href{https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids}{Spotify IDs} for a seed track. Up to 5 seed values may be provided in any combination of \code{seed_artists}, \code{seed_tracks} and \code{seed_genres}.}
 
@@ -128,7 +128,7 @@ get_recommendations(limit = 20, market = NULL, seed_artists = NULL,
 \item{include_seeds_in_response}{Optional. Boolean for whether to include seed object in response. Defaults to \code{FALSE}.}
 }
 \value{
-Returns a data frame of results recommendations. See the official \href{https://developer.spotify.com/documentation/web-api/reference/browse/get-recommendations/}{Spotify Web API documentation} for more information.
+Returns a data frame of results recommendations. See the official \href{https://developer.spotify.com/documentation/web-api}{Spotify Web API documentation} for more information.
 }
 \description{
 Create a playlist-style listening experience based on seed artists, tracks and genres.

--- a/man/get_related_artists.Rd
+++ b/man/get_related_artists.Rd
@@ -14,7 +14,7 @@ get_related_artists(id, authorization = get_spotify_access_token(),
 \item{include_meta_info}{Optional. Boolean indicating whether to include full result, with meta information such as \code{"total"}, and \code{"limit"}. Defaults to \code{FALSE}.}
 }
 \value{
-Returns a data frame of results containing artist data. See \url{https://developer.spotify.com/documentation/web-api/reference/artists/get-several-artists/} for more information.
+Returns a data frame of results containing artist data. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 }
 \description{
 Get Spotify catalog information about artists similar to a given artist. Similarity is based on analysis of the Spotify community’s listening history.

--- a/man/get_show.Rd
+++ b/man/get_show.Rd
@@ -16,7 +16,7 @@ If not given, results will be returned for all markets and you are likely to get
 \item{authorization}{Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization Guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}}
 }
 \value{
-Returns a data frame of results containing show data. See \url{https://developer.spotify.com/documentation/web-api/reference/shows/get-a-show/} for more information.
+Returns a data frame of results containing show data. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 }
 \description{
 Get Spotify catalog information for a single show identified by their unique Spotify ID.

--- a/man/get_shows.Rd
+++ b/man/get_shows.Rd
@@ -16,7 +16,7 @@ If not given, results will be returned for all markets and you are likely to get
 \item{authorization}{Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization Guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}}
 }
 \value{
-Returns a data frame of results containing show data. See \url{https://developer.spotify.com/documentation/web-api/reference/shows/get-a-show/} for more information.
+Returns a data frame of results containing show data. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 }
 \description{
 Get Spotify catalog information for a single show identified by their unique Spotify ID.

--- a/man/get_shows_episodes.Rd
+++ b/man/get_shows_episodes.Rd
@@ -16,7 +16,7 @@ If not given, results will be returned for all markets and you are likely to get
 \item{authorization}{Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization Guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}}
 }
 \value{
-Returns a data frame of results containing the episode data for a show. See \url{https://developer.spotify.com/documentation/web-api/reference/shows/get-shows-episodes/} for more information.
+Returns a data frame of results containing the episode data for a show. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 }
 \description{
 Get Spotify catalog information for a show's episodes identified by their unique Spotify ID.

--- a/man/get_track.Rd
+++ b/man/get_track.Rd
@@ -14,7 +14,7 @@ An ISO 3166-1 alpha-2 country code or the string \code{"from_token"}. Provide th
 \item{authorization}{Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}}
 }
 \value{
-Returns a data frame of results containing track data. See \url{https://developer.spotify.com/documentation/web-api/reference/tracks/get-several-tracks/} for more information.
+Returns a data frame of results containing track data. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 }
 \description{
 Get Spotify catalog information for a single track identified by its unique Spotify ID.

--- a/man/get_track_audio_analysis.Rd
+++ b/man/get_track_audio_analysis.Rd
@@ -11,7 +11,7 @@ get_track_audio_analysis(id, authorization = get_spotify_access_token())
 \item{authorization}{Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}}
 }
 \value{
-Returns a data frame of results containing track audio analysis data. See \url{https://developer.spotify.com/documentation/web-api/reference/tracks/get-audio-analysis/} for more information.
+Returns a data frame of results containing track audio analysis data. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 }
 \description{
 Get a detailed audio analysis for a single track identified by its unique Spotify ID.

--- a/man/get_track_audio_features.Rd
+++ b/man/get_track_audio_features.Rd
@@ -11,7 +11,7 @@ get_track_audio_features(ids, authorization = get_spotify_access_token())
 \item{authorization}{Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}}
 }
 \value{
-Returns a data frame of results containing track audio features data. See \url{https://developer.spotify.com/documentation/web-api/reference/tracks/get-several-audio-features/} for more information.
+Returns a data frame of results containing track audio features data. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 }
 \description{
 Get audio feature information for a single track identified by its unique Spotify ID.

--- a/man/get_tracks.Rd
+++ b/man/get_tracks.Rd
@@ -17,7 +17,7 @@ An ISO 3166-1 alpha-2 country code or the string \code{"from_token"}. Provide th
 \item{include_meta_info}{Optional. Boolean indicating whether to include full result, with meta information such as \code{"total"}, and \code{"limit"}. Defaults to \code{FALSE}.}
 }
 \value{
-Returns a data frame of results containing track data. See \url{https://developer.spotify.com/documentation/web-api/reference/tracks/get-several-tracks/} for more information.
+Returns a data frame of results containing track data. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 }
 \description{
 Get Spotify catalog information for a single track identified by its unique Spotify ID.

--- a/man/get_user_playlists.Rd
+++ b/man/get_user_playlists.Rd
@@ -27,7 +27,7 @@ Collaborative playlists are only retrievable for the current user and requires t
 \item{include_meta_info}{Optional. Boolean indicating whether to include full result, with meta information such as \code{"total"}, and \code{"limit"}. Defaults to \code{FALSE}.}
 }
 \value{
-Returns a data frame of results containing user playlist information. See the official \href{https://developer.spotify.com/documentation/web-api/reference/playlists/get-list-users-playlists/}{Spotify Web API documentation} for more information.
+Returns a data frame of results containing user playlist information. See the official \href{https://developer.spotify.com/documentation/web-api}{Spotify Web API documentation} for more information.
 }
 \description{
 Get a list of the playlists owned or followed by a Spotify user.

--- a/man/get_user_profile.Rd
+++ b/man/get_user_profile.Rd
@@ -11,7 +11,7 @@ get_user_profile(user_id, authorization = get_spotify_access_token())
 \item{authorization}{Required. A valid access token from the Spotify Accounts service. See the \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}}
 }
 \value{
-Returns a data frame of results containing user profile information. See \url{https://developer.spotify.com/documentation/web-api/reference/users-profile/get-users-profile/} for more information.
+Returns a data frame of results containing user profile information. See \url{https://developer.spotify.com/documentation/web-api} for more information.
 }
 \description{
 Get public profile information about a Spotify user.

--- a/man/search_spotify.Rd
+++ b/man/search_spotify.Rd
@@ -52,7 +52,7 @@ By default external content is filtered out from responses.}
 Returns a data frame of results containing search data.
 }
 \description{
-Get Spotify Catalog information about artists, albums, tracks or playlists that match a keyword string. For more information see the official \href{https://developer.spotify.com/documentation/web-api/reference/#category-search}{documentation}.
+Get Spotify Catalog information about artists, albums, tracks or playlists that match a keyword string. For more information see the official \href{https://developer.spotify.com/documentation/web-api}{documentation}.
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
Pre-submission cleanup (walked the CRAN cookbook checklist):

- **URLs (CRAN NOTE):** 38 dead Spotify `/reference/<cat>/<endpoint>/` doc URLs (404) -> API-reference root; README `tinyverse` http->https; `charlie86/spotifyr` (301) -> live target.
- **Code:** `auto_unbox = T` -> `TRUE`.
- **DESCRIPTION:** `cph` role added to the two LICENSE copyright holders; version 0.2.3 + Date.

`R CMD check`: 0 errors, 0 warnings, 1 NOTE ("New maintainer" — the gmail->cornball.ai change, confirmed at submission). Submitted to win-builder (R-devel + R-release); results email to the maintainer.