### PR TITLE
Fix get_shows_episodes() sending market parameter twice

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tinyspotifyr
 Title: Tinyverse R Wrapper for the 'Spotify' Web API
-Version: 0.2.3.1
+Version: 0.2.3.2
 Date: 2026-06-06
 Authors@R: c(person("Troy", "Hernandez", email = "troy@cornball.ai", role = c("aut", "cre", "cph"), comment = c(ORCID = "0009-0005-4248-604X")), person("Charlie", "Thompson", email = "chuck@rcharlie.com", role = c("aut", "cph")), person("Josiah", "Parry", email = "josiah.parry@yahoo.com", role = "aut"), person("Donal", "Phipps", email = "donal.phipps@gmail.com", role = "aut"), person("Tom", "Wolff", email = "tom.wolff@duke.edu", role = "aut"))
 Description: An R wrapper for the 'Spotify' Web API

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# tinyspotifyr 0.2.3.2
+
+* Fixed `get_shows_episodes()` sending `market` twice (in the URL and via the
+  query), producing a malformed query and a Spotify "Invalid market parameter"
+  400. Another migration leftover, like the get_artist()/get_album() fixes in
+  0.2.3.1.
+
 # tinyspotifyr 0.2.3.1
 
 * Replaced the httr backend with tinyoauth (curl + jsonlite + serverSocket); Imports trimmed to tinyoauth alone. Existing httr .httr-oauth caches carry over via oauth_import_httr() (no re-login).

--- a/R/shows.R
+++ b/R/shows.R
@@ -63,7 +63,7 @@ get_shows_episodes <- function(id, market = "US",
     base_url <- 'https://api.spotify.com/v1/shows'
 
     params <- list(market = market)
-    url <- paste0(base_url, "/", id, "/episodes?market=", market)
+    url <- paste0(base_url, "/", id, "/episodes")
     res <- tinyoauth::oauth_request(authorization, url, "GET",
                                     query = params, flatten = TRUE)
 


### PR DESCRIPTION
Reported via `add_latest_to_playlist()`: `HTTP 400: Invalid market parameter`.

`get_shows_episodes()` put `market` in the URL **and** passed it via `query=`, so `tinyoauth::oauth_request()`'s `paste0(url, "?", query)` produced `.../episodes?market=US?market=US`. Spotify parsed the market as `US?market=US` and returned 400. tinyspotifyr bug, not tinyoauth — a leftover from the httr→tinyoauth migration (sibling `get_artist()`/`get_album()` were fixed in 0.2.3.1).

Fix: build the path only and let `oauth_request()` add the query, matching the other `shows.R` functions. Verified the corrected build yields a single `.../episodes?market=US`.