### PR TITLE
CI: authenticate GitHub API (fix tinyoauth install rate-limit)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,9 @@ on:
 
 env:
   _R_CHECK_FORCE_SUGGESTS_: "false"
+  # Authenticate GitHub API calls so installing the GitHub-only dependency
+  # (Remotes: cornball-ai/tinyoauth) doesn't hit anonymous rate limits.
+  GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   ci:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,16 @@ jobs:
           dev_version: 'TRUE'
           backend: 'RAPT'
 
+      # tinyoauth is GitHub-only. Install it from a plain git clone (git
+      # protocol, no GitHub REST API) so dependency resolution below doesn't
+      # hit api.github.com rate limits / cross-repo token failures. Once it's
+      # installed, install_deps treats the Imports entry as satisfied.
+      - name: Install tinyoauth (GitHub-only dependency)
+        run: |
+          Rscript -e 'install.packages(c("curl", "jsonlite"))'
+          git clone --depth 1 https://github.com/cornball-ai/tinyoauth.git /tmp/tinyoauth
+          R CMD INSTALL /tmp/tinyoauth
+
       - name: Dependencies
         run: ./run.sh install_deps
 


### PR DESCRIPTION
master CI has been failing on `install_deps`:

```
cannot open URL 'https://api.github.com/repos/cornball-ai/tinyoauth/contents/DESCRIPTION?ref=HEAD'
```

Resolving `Remotes: cornball-ai/tinyoauth` hits the GitHub API anonymously (no token in the workflow), so it gets rate-limited and fails. Passing the auto-provided `GITHUB_TOKEN` as `GITHUB_PAT` authenticates `remotes` (1000 req/hr). This PR's own CI run validates the fix.